### PR TITLE
hsbench: Limit idle connections to 2x the thread count.

### DIFF
--- a/hsbench.go
+++ b/hsbench.go
@@ -54,10 +54,10 @@ var HTTPTransport http.RoundTripper = &http.Transport{
 	}).Dial,
 	TLSHandshakeTimeout:   10 * time.Second,
 	ExpectContinueTimeout: 0,
-	// Allow an unlimited number of idle connections
-	MaxIdleConnsPerHost: 4096,
-	MaxIdleConns:        0,
-	// But limit their idle time
+	// Set the number of idle connections to 2X the number of threads 
+	MaxIdleConnsPerHost: 2*threads,
+	MaxIdleConns:        2*threads,
+	// But limit their idle time to 1 minute
 	IdleConnTimeout: time.Minute,
 	// Ignore TLS errors
 	TLSClientConfig: &tls.Config{InsecureSkipVerify: true},


### PR DESCRIPTION
Eventually if we support multiple S3 endpoints we may change the PerHost limit, but for now set both of these to 2 times the number of threads.

Signed-off-by: Mark Nelson <mnelson@redhat.com>